### PR TITLE
Only use first line of git commit message when building redmine message

### DIFF
--- a/server.py
+++ b/server.py
@@ -69,6 +69,9 @@ def create_issue_update(pullrequest, data):
             return verb + 'd'
         return verb
 
+    def first_line(text):
+        return text.split('\n')[0] if text else ''
+
     loader = tornado.template.Loader(
         os.path.join(os.path.dirname(__file__), 'templates')
     )
@@ -78,6 +81,7 @@ def create_issue_update(pullrequest, data):
         head_url=create_tree_url(data, 'head'),
         base_url=create_tree_url(data, 'base'),
         make_past_tense=make_past_tense,
+        first_line=first_line,
         commits=get_commits_from_pr(pullrequest),
     )
 

--- a/templates/updated_pull_request.textile
+++ b/templates/updated_pull_request.textile
@@ -1,3 +1,3 @@
 "PR {{ data['number'] }}: {{ data['pull_request']['title'] }}":{{ data['pull_request']['html_url'] }} from "{{ data['pull_request']['head']['repo']['full_name'] }}/{{ data['pull_request']['head']['ref'] }}":{{ head_url }} into "{{ data['pull_request']['base']['repo']['full_name'] }}/{{ data['pull_request']['base']['ref'] }}":{{ base_url }} {{ make_past_tense(data['action']) }} by "{{ data['sender']['login'] }}":{{ data['sender']['html_url'] }}
 
-Most recent commit: "{{ commits[-1].commit.message }}":{{ commits[-1]._rawData['html_url'] }}
+Most recent commit: "{{ first_line(commits[-1].commit.message) }}":{{ commits[-1]._rawData['html_url'] }}


### PR DESCRIPTION
Fix for gs-1068
### Referenced Issues:
- [Issue 1068: corgi: Link inserted in Redmine broken for multiline git commit messages ](https://projects.glencoesoftware.com/issues/1068)
